### PR TITLE
Fix for code blocks containing HTML tags

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -37,7 +37,7 @@ const microdown = function () {
       (match, wrapper, c, text, tag) =>
         wrapper === '"""' ?
           t('div', parse(text), { class: c })
-          : t('pre', text, { class: c }),
+          : t('pre', e(text), { class: c }),
 
       // blockquotes
       /(^>.*\n?)+/gm,

--- a/src/index.js
+++ b/src/index.js
@@ -14,7 +14,7 @@ const microdown = function () {
      */
     e = (text) => {
         return text !== undefined ? text.replace(/"/g, '&quot;').replace(/</g, '&lt;').replace(/>/g, '&gt;') : '';
-    }
+    },
     /**
      * recursive list parser
      */

--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,7 @@ const microdown = function () {
   /*
    * tag helper
    */
-  var t = (tag, text, values) => `<${tag + (values ? ' ' + Object.keys(values).map(k => `${k}="${values[k] || ''}"`).join(' ') : '')}>${text}</${tag}>`,
+  var t = (tag, text, values) => `<${tag + (values ? ' ' + Object.keys(values).map(k => `${k}="${e(values[k]) || ''}"`).join(' ') : '')}>${text}</${tag}>`,
     /**
      * outdent all rows by first as reference
      */
@@ -13,7 +13,7 @@ const microdown = function () {
      * encode existing HTML tags to entities in a string
      */
     e = (text) => {
-        return text.replace(/</g, '&lt;').replace(/>/g, '&gt;');
+        return text.replace(/"/g, '&quot;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
     }
     /**
      * recursive list parser

--- a/src/index.js
+++ b/src/index.js
@@ -10,10 +10,10 @@ const microdown = function () {
       return text.replace(new RegExp('^' + (text.match(/^[^\s]?\s+/) || '')[0], 'gm'), '');
     },
     /**
-     * encode existing HTML tags to entities in a string
+     * encode double quotes and HTML tags to entities
      */
     e = (text) => {
-        return text.replace(/"/g, '&quot;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+        return text !== undefined ? text.replace(/"/g, '&quot;').replace(/</g, '&lt;').replace(/>/g, '&gt;') : '';
     }
     /**
      * recursive list parser

--- a/src/index.js
+++ b/src/index.js
@@ -10,6 +10,12 @@ const microdown = function () {
       return text.replace(new RegExp('^' + (text.match(/^[^\s]?\s+/) || '')[0], 'gm'), '');
     },
     /**
+     * encode existing HTML tags to entities in a string
+     */
+    e = (text) => {
+        return text.replace(/</g, '&lt;').replace(/>/g, '&gt;');
+    }
+    /**
      * recursive list parser
      */
     l = (text, temp) => {
@@ -62,7 +68,7 @@ const microdown = function () {
 
       // extrude pre format inline
       /`([^`]*)`/g,
-      (match, text) => t('code', text),
+      (match, text) => t('code', e(text)),
 
       //anchor
       /#\[([^\]]+)\]/g,


### PR DESCRIPTION
Fixes #4 at least for code blocks, could be that HTML tags within other blocks or inline elements mess up the parser too, let me know if there is a better place to apply the new `e()` method!